### PR TITLE
mysqlbinlogなどのツールも含めたcharacter-set指定

### DIFF
--- a/my_cnf_80_master.ini
+++ b/my_cnf_80_master.ini
@@ -39,4 +39,4 @@ default-character-set = utf8mb4
 # mysqlクライアントツールの設定
 [client]
 # 文字コードの設定
-default-character-set = utf8mb4
+loose-default-character-set = utf8mb4

--- a/my_cnf_80_slave.ini
+++ b/my_cnf_80_slave.ini
@@ -38,4 +38,4 @@ default-character-set = utf8mb4
 # mysqlクライアントツールの設定
 [client]
 # 文字コードの設定
-default-character-set = utf8mb4
+loose-default-character-set = utf8mb4


### PR DESCRIPTION
- mysqlbinlogなどのcharacter指定が `default-character-set` ではなされないため変更
https://yoku0825.blogspot.com/2017/11/mysqlbinlog-error-unknown-variable.html